### PR TITLE
Fix mood indicator visibility check

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -136,7 +136,7 @@ const Canvas: React.FC<CanvasProps> = ({ width, height, onEntityClick }) => {
     }
 
     // Indicador de humor (emoji)
-    if (feedback.moodIndicator && quality === 'medium' || quality === 'high') {
+    if (feedback.moodIndicator && (quality === 'medium' || quality === 'high')) {
       ctx.font = '16px sans-serif';
       ctx.textAlign = 'center';
       ctx.fillText(feedback.moodIndicator, entity.position.x + 20, entity.position.y - 20);


### PR DESCRIPTION
## Summary
- fix the boolean condition that decides when to draw the mood indicator

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845bef72cd8832c9b7ac136c93e9438